### PR TITLE
Fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-#Daniel Schwarz
+# Daniel Schwarz
 
 
-##What is your developer journey so far? What brought you to this major, and why did you take this class?
+## What is your developer journey so far? What brought you to this major, and why did you take this class?
 My developer journey isn't exactly remarkable so far. I have taken the standard Towson University Computer Science major classes and i have a fondness for C++.
 I decided that Comp Sci was the major for me after working for Wal-Mart for seven years. I simply googled "highest paying college degrees" and picked Comp Sci 
 because it came up as the fastest growing job market. I'm taking this class because it is required from the major, but putting web-design on a resume can't hurt as well.
 
-##What is your ideal career progression, if there were no limitations?
+## What is your ideal career progression, if there were no limitations?
 Ideally I would like to program tax software for an oblivious client. I would change 3-4 variables a year and claim that it takes months to implement because the client
 isn't too familiar with computer science or the workload when it comes to coding. I want to make enough money to buy every stupid impulse purchase that comes to mind without
 the regret of wasting money on something pointless.
 
-##What programming experience do you have? Do you have any web experience?
+## What programming experience do you have? Do you have any web experience?
 I am familiar with C, C++, Python, Java, CSS, x86 assembly, F#, Ocaml and SQl. I have limited web experience, but I worked on a group project last semester formatting a website using CSS.
 
-#Link to Code Acedemy Profile
-https://www.codecademy.com/dschwa19
+[Link to Code Acedemy Profile](https://www.codecademy.com/dschwa19)


### PR DESCRIPTION
Markdown is very sensitive to whitespace, and has its own link format. While direct URLs will work, it is usually more favorable to use a hyperlink.